### PR TITLE
Updated job processing

### DIFF
--- a/src/MessageReplay/Jobs/ReplayJob.cs
+++ b/src/MessageReplay/Jobs/ReplayJob.cs
@@ -20,12 +20,14 @@ public class ReplayJob(
     {
         var files = blobService.GetResourcesAsync(prefix, cancellationToken);
 
-        await Parallel.ForEachAsync(files,
+        await Parallel.ForEachAsync(
+            files,
             new ParallelOptions() { CancellationToken = cancellationToken, MaxDegreeOfParallelism = 8 },
             async (file, token) =>
             {
-               await Task.Run(() => ProcessBlob(file, Guid.NewGuid().ToString("N"), context, token), token);
-            });
+                await Task.Run(() => ProcessBlob(file, Guid.NewGuid().ToString("N"), context, token), token);
+            }
+        );
     }
 
     [JobDisplayName("Replaying blob - {0}")]

--- a/src/MessageReplay/Jobs/ReplayJob.cs
+++ b/src/MessageReplay/Jobs/ReplayJob.cs
@@ -20,32 +20,43 @@ public class ReplayJob(
     {
         var files = blobService.GetResourcesAsync(prefix, cancellationToken);
 
-        await foreach (var file in files)
-        {
-            var state = new AwaitingState(
-                context.BackgroundJob.Id,
-                new EnqueuedState(),
-                JobContinuationOptions.OnlyOnSucceededState
-            );
-            jobManager.Create(
-                Job.FromExpression(
-                    () => ProcessBlob(file, Guid.NewGuid().ToString("N"), null!, CancellationToken.None),
-                    context.BackgroundJob.Job.Queue
-                ),
-                state
-            );
-        }
+        await Parallel.ForEachAsync(files,
+            new ParallelOptions() { CancellationToken = cancellationToken, MaxDegreeOfParallelism = 8 },
+            async (file, token) =>
+            {
+               await Task.Run(() => ProcessBlob(file, Guid.NewGuid().ToString("N"), context, token), token);
+            });
     }
 
     [JobDisplayName("Replaying blob - {0}")]
     public async Task ProcessBlob(string file, string traceId, PerformContext context, CancellationToken token)
     {
-        traceContextAccessor.Context = new TraceContext() { TraceId = traceId };
-        logger.LogInformation("TraceId = {TraceId}", traceId);
-        var blobItem = await blobService.GetResource(file, token);
-        foreach (var blobProcessor in blobProcessors.Where(x => x.CanProcess(context.BackgroundJob.Job.Queue)))
+        try
         {
-            await blobProcessor.Process(blobItem);
+            traceContextAccessor.Context = new TraceContext() { TraceId = traceId };
+            logger.LogInformation("TraceId = {TraceId}", traceId);
+            var blobItem = await blobService.GetResource(file, token);
+            foreach (var blobProcessor in blobProcessors.Where(x => x.CanProcess(context.BackgroundJob.Job.Queue)))
+            {
+                await blobProcessor.Process(blobItem);
+            }
+        }
+        catch (Exception)
+        {
+            // swallow exception but add a specific continuation job, so it can be tracked and retried
+            var state = new AwaitingState(
+                context.BackgroundJob.Id,
+                new EnqueuedState(),
+                JobContinuationOptions.OnlyOnSucceededState
+            );
+
+            jobManager.Create(
+                Job.FromExpression(
+                    () => ProcessBlob(file, traceId, null!, CancellationToken.None),
+                    context.BackgroundJob.Job.Queue
+                ),
+                state
+            );
         }
     }
 }

--- a/src/MessageReplay/appsettings.json
+++ b/src/MessageReplay/appsettings.json
@@ -10,21 +10,22 @@
       "Default": "Information",
       "Override": {
         "Microsoft": "Information",
-        "System": "Information"
+        "System": "Information",
+        "Hangire": "Warning"
       }
     },
     "Enrich": [ "WithHangfireContext" ],
-    "WriteTo": [
-      {
-        "Name": "Hangfire",
-        "Args": {
-          "restrictedToMinimumLevel": "Information"
-        }
-      },
+    "WriteTo": [      
       {
         "Name": "Async",
         "Args": {
           "configure": [
+            {
+              "Name": "Hangfire",
+              "Args": {
+                "restrictedToMinimumLevel": "Warning"
+              }
+            },
             {
               "Name": "Console",
               "Args": {

--- a/tests/MessageReplay.Tests/Jobs/ReplayJobTests.cs
+++ b/tests/MessageReplay.Tests/Jobs/ReplayJobTests.cs
@@ -8,6 +8,7 @@ using Hangfire.Server;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Identity.Client.Extensions.Msal;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Defra.TradeImportsMessageReplay.MessageReplay.Tests.Jobs;
 
@@ -22,6 +23,45 @@ public class ReplayJobTests
         blobService.GetResourcesAsync("Test", CancellationToken.None).Returns(blobs.ToAsyncEnumerable());
 
         var blobProcessor = Substitute.For<IBlobProcessor>();
+
+        blobProcessor.CanProcess(Arg.Any<string>()).Returns(true);
+
+        var sut = new ReplayJob(
+            blobService,
+            [blobProcessor],
+            backgroundJobClient,
+            new TraceContextAccessor(),
+            NullLogger<ReplayJob>.Instance
+        );
+        var storage = new InMemoryStorage();
+        await sut.Run(
+            "Test",
+            new PerformContext(
+                storage,
+                storage.GetConnection(),
+                new BackgroundJob(
+                    "test",
+                    new Job(typeof(ReplayJobTests).GetMethod(nameof(When_job_run_blobs_should_be_processed))),
+                    DateTime.Now
+                ),
+                new JobCancellationToken(false)
+            ),
+            CancellationToken.None
+        );
+
+        await blobProcessor.Received(1).Process(Arg.Any<BlobItem>());
+    }
+
+    [Fact]
+    public async Task When_job_run_fails_blobs_should_be_processed()
+    {
+        var blobs = new List<string> { "Test blob 1" };
+        var blobService = Substitute.For<IBlobService>();
+        var backgroundJobClient = Substitute.For<IBackgroundJobClient>();
+        blobService.GetResourcesAsync("Test", CancellationToken.None).Returns(blobs.ToAsyncEnumerable());
+
+        var blobProcessor = Substitute.For<IBlobProcessor>();
+        blobProcessor.Process(Arg.Any<BlobItem>()).ThrowsAsync(new Exception());
 
         blobProcessor.CanProcess(Arg.Any<string>()).Returns(true);
 


### PR DESCRIPTION
This PR updates the hangfire logging to be async.  It turns out that for every log every hangfire creates a new mongo document, and this is done in sync.  As we already have the logs somewhere else, then to avoid duplicating logs, the level has been changed to warning, and for the writing to mongo to be done in a background task.

This PR also changes the creating of a new task for every blob, now it will try and process the blob and if it fails it will create a continuation task so that one blob can be retried.  Think of the continuation tasks more of a DLQ.

Also updated the job to use a Parallel.ForEach loop so it can process multiple blobs at a time.

As a side of effect of this, assuming there are no errors on the job, 1 job is run on a single process, so we lose the ability to scale the job over multiple servers, however the replay service will need to throttle the throughput, so this might not be a bad
 thing.